### PR TITLE
Move doctrine/annotations to require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,13 +23,13 @@
         "php": "~7.4|~8.2",
         "ext-intl": "*",
         "ext-json": "*",
-        "doctrine\/annotations": "^1.0|^2.0",
         "guzzlehttp\/guzzle": "~6|^7.2",
         "jms\/serializer": "^3.1",
         "monolog\/monolog": "^3.7",
         "webdevvie\/nestis": "^1.0"
     },
     "require-dev": {
+        "doctrine\/annotations": "^1.0|^2.0",
         "mikey179\/vfsstream": "^1.6",
         "mockery\/mockery": "^1.3",
         "phpmd\/phpmd": "^2.8.2",


### PR DESCRIPTION
This pull request marks the `doctrine/annotations` package as needed for development only, so that API client users do not need to pull in that dependency, which has officially been abandoned on Packagist and therefore could violate Composer security policies that users may have.